### PR TITLE
Fix undefined variable $hours_left

### DIFF
--- a/includes/class.cooked-measurements.php
+++ b/includes/class.cooked-measurements.php
@@ -653,6 +653,7 @@ class Cooked_Measurements {
 			endif;
 		else:
 			$days = floor( $minutes / 24 / 60 );
+			$hours_left = 0;
 			$minutes_left = $minutes - ( $days * 24 * 60 );
 			if ( $minutes_left > 60 ):
 				$hours_left = floor( $minutes_left / 60 );


### PR DESCRIPTION
To fix issue #10 , I define $hours_left, in the case where $minutes is greater than or equal to 1440.