### PR TITLE
Update widgets code from WordPress SVN repo

### DIFF
--- a/includes/widgets/nutrition.php
+++ b/includes/widgets/nutrition.php
@@ -37,7 +37,7 @@ class Cooked_Widget_Nutrition extends WP_Widget {
 
     public function update( $new_instance, $old_instance ) {
         $instance = array();
-        $instance['title'] = ( ! empty( $new_instance['title'] ) ) ? strip_tags( $new_instance['title'] ) : '';
+        $instance['title'] = ( ! empty( $new_instance['title'] ) ) ? wp_strip_all_tags( $new_instance['title'] ) : '';
         return $instance;
     }
 

--- a/includes/widgets/recipe-card.php
+++ b/includes/widgets/recipe-card.php
@@ -133,14 +133,14 @@ class Cooked_Widget_Recipe_Card extends WP_Widget {
 
     public function update( $new_instance, $old_instance ) {
         $instance = array();
-        $instance['title'] = ( !empty( $new_instance['title'] ) ? strip_tags( $new_instance['title'] ) : '' );
-        $instance['recipe_id'] = ( !empty( $new_instance['recipe_id'] ) ? strip_tags( $new_instance['recipe_id'] ) : false );
-        $instance['width'] = ( !empty( $new_instance['width'] ) ? strip_tags( $new_instance['width'] ) : '100%' );
-        $instance['style'] = ( !empty( $new_instance['style'] ) ? strip_tags( $new_instance['style'] ) : false );
-        $instance['hide_image'] = ( !empty( $new_instance['hide_image'] ) ? strip_tags( $new_instance['hide_image'] ) : false );
-        $instance['hide_title'] = ( !empty( $new_instance['hide_title'] ) ? strip_tags( $new_instance['hide_title'] ) : false );
-        $instance['hide_excerpt'] = ( !empty( $new_instance['hide_excerpt'] ) ? strip_tags( $new_instance['hide_excerpt'] ) : false );
-        $instance['hide_author'] = ( !empty( $new_instance['hide_author'] ) ? strip_tags( $new_instance['hide_author'] ) : false );
+        $instance['title'] = ( !empty( $new_instance['title'] ) ? wp_strip_all_tags( $new_instance['title'] ) : '' );
+        $instance['recipe_id'] = ( !empty( $new_instance['recipe_id'] ) ? wp_strip_all_tags( $new_instance['recipe_id'] ) : false );
+        $instance['width'] = ( !empty( $new_instance['width'] ) ? wp_strip_all_tags( $new_instance['width'] ) : '100%' );
+        $instance['style'] = ( !empty( $new_instance['style'] ) ? wp_strip_all_tags( $new_instance['style'] ) : false );
+        $instance['hide_image'] = ( !empty( $new_instance['hide_image'] ) ? wp_strip_all_tags( $new_instance['hide_image'] ) : false );
+        $instance['hide_title'] = ( !empty( $new_instance['hide_title'] ) ? wp_strip_all_tags( $new_instance['hide_title'] ) : false );
+        $instance['hide_excerpt'] = ( !empty( $new_instance['hide_excerpt'] ) ? wp_strip_all_tags( $new_instance['hide_excerpt'] ) : false );
+        $instance['hide_author'] = ( !empty( $new_instance['hide_author'] ) ? wp_strip_all_tags( $new_instance['hide_author'] ) : false );
         return $instance;
     }
 

--- a/includes/widgets/recipe-categories.php
+++ b/includes/widgets/recipe-categories.php
@@ -64,9 +64,9 @@ class Cooked_Widget_Recipe_Categories extends WP_Widget {
     public function update( $new_instance, $old_instance ) {
 
         $instance = array();
-        $instance['title'] = ( !empty( $new_instance['title'] ) ? strip_tags( $new_instance['title'] ) : '' );
-        $instance['child_of'] = ( !empty( $new_instance['child_of'] ) ? strip_tags( $new_instance['child_of'] ) : false );
-        $instance['hide_empty'] = ( !empty( $new_instance['hide_image'] ) ? strip_tags( $new_instance['hide_image'] ) : false );
+        $instance['title'] = ( !empty( $new_instance['title'] ) ? wp_strip_all_tags( $new_instance['title'] ) : '' );
+        $instance['child_of'] = ( !empty( $new_instance['child_of'] ) ? wp_strip_all_tags( $new_instance['child_of'] ) : false );
+        $instance['hide_empty'] = ( !empty( $new_instance['hide_image'] ) ? wp_strip_all_tags( $new_instance['hide_image'] ) : false );
         return $instance;
     }
 

--- a/includes/widgets/recipe-list.php
+++ b/includes/widgets/recipe-list.php
@@ -99,13 +99,13 @@ class Cooked_Widget_Recipe_List extends WP_Widget {
     public function update( $new_instance, $old_instance ) {
 
         $instance = array();
-        $instance['title'] = ( !empty( $new_instance['title'] ) ? strip_tags( $new_instance['title'] ) : '' );
-        $instance['orderby'] = ( !empty( $new_instance['orderby'] ) ? strip_tags( $new_instance['orderby'] ) : 'date' );
-        $instance['width'] = ( !empty( $new_instance['width'] ) ? strip_tags( $new_instance['width'] ) : '100%' );
-        $instance['show'] = ( !empty( $new_instance['show'] ) ? strip_tags( $new_instance['show'] ) : 5 );
+        $instance['title'] = ( !empty( $new_instance['title'] ) ? wp_strip_all_tags( $new_instance['title'] ) : '' );
+        $instance['orderby'] = ( !empty( $new_instance['orderby'] ) ? wp_strip_all_tags( $new_instance['orderby'] ) : 'date' );
+        $instance['width'] = ( !empty( $new_instance['width'] ) ? wp_strip_all_tags( $new_instance['width'] ) : '100%' );
+        $instance['show'] = ( !empty( $new_instance['show'] ) ? wp_strip_all_tags( $new_instance['show'] ) : 5 );
         $instance['recipes'] = ( !empty( $new_instance['recipes'] ) ? $new_instance['recipes'] : '' );
-        $instance['hide_image'] = ( !empty( $new_instance['hide_image'] ) ? strip_tags( $new_instance['hide_image'] ) : false );
-        $instance['hide_author'] = ( !empty( $new_instance['hide_author'] ) ? strip_tags( $new_instance['hide_author'] ) : false );
+        $instance['hide_image'] = ( !empty( $new_instance['hide_image'] ) ? wp_strip_all_tags( $new_instance['hide_image'] ) : false );
+        $instance['hide_author'] = ( !empty( $new_instance['hide_author'] ) ? wp_strip_all_tags( $new_instance['hide_author'] ) : false );
         return $instance;
     }
 

--- a/includes/widgets/search.php
+++ b/includes/widgets/search.php
@@ -61,8 +61,8 @@ class Cooked_Widget_Search extends WP_Widget {
 
     public function update( $new_instance, $old_instance ) {
         $instance = array();
-        $instance['title'] = ( ! empty( $new_instance['title'] ) ) ? strip_tags( $new_instance['title'] ) : '';
-        $instance['size'] = ( ! empty( $new_instance['size'] ) ) ? strip_tags( $new_instance['size'] ) : 'compact';
+        $instance['title'] = ( ! empty( $new_instance['title'] ) ) ? wp_strip_all_tags( $new_instance['title'] ) : '';
+        $instance['size'] = ( ! empty( $new_instance['size'] ) ) ? wp_strip_all_tags( $new_instance['size'] ) : 'compact';
         $instance['hide_browse'] = ( !isset( $new_instance['hide_browse'] ) ? 0 : 1 );
         $instance['hide_sorting'] = ( !isset( $new_instance['hide_sorting'] ) ? 0 : 1 );
         return $instance;


### PR DESCRIPTION
I was looking at the diff between 1.7.15.1 in the WordPress SVN repo compared to the latest version here. And I noticed the WP version has `strip_tags` replaced with `wp_strip_all_tags` in the files under the /includes/widgets dir. So this brings those changes over if you want. I'm not sure if you left them out for a reason or just haven't seen them, but I'll let you decide if you want to add those changes in with this PR.