### PR TITLE
Fixed HTML showing in front-end

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,8 +5,8 @@ Versions that are currently being supported with security updates.
 
 | Version     | Supported          |
 | -------     | ------------------ |
-| 1.7.15.2    | :white_check_mark: |
-| <= 1.7.15.1 | :x:                |
+| 1.7.15.3    | :white_check_mark: |
+| <= 1.7.15.2 | :x:                |
 
 ## Reporting a Vulnerability
 

--- a/cooked.php
+++ b/cooked.php
@@ -6,7 +6,7 @@ Plugin URI: 	https://wordpress.org/plugins/cooked/
 Description: 	A recipe plugin for WordPress.
 Author: 		Boxy Studio
 Author URI: 	https://boxystudio.com
-Version: 		1.7.15.2
+Version: 		1.7.15.3
 Text Domain: 	cooked
 Domain Path: 	languages
 License:     	GPL2
@@ -30,7 +30,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 
 require_once __DIR__ . '/vendor/autoload.php';
 
-define( 'COOKED_VERSION', '1.7.15.2' );
+define( 'COOKED_VERSION', '1.7.15.3' );
 define( 'COOKED_DEV', true );
 
 if ( ! class_exists( 'Cooked_Plugin' ) ) :

--- a/includes/class.cooked-recipes.php
+++ b/includes/class.cooked-recipes.php
@@ -967,7 +967,7 @@ class Cooked_Recipes {
 					$view_all_recipes_url = false;
 				endif;
 
-				if ( in_array( 'cp_recipe_category',$_cooked_settings['recipe_taxonomies']) ):
+				if ( in_array( 'cp_recipe_category', $_cooked_settings['recipe_taxonomies']) ):
 					$terms_array = Cooked_Settings::terms_array( 'cp_recipe_category', false, esc_html__('No categories','cooked'), true, true, false );
 					if ( !empty($terms_array) ):
 						echo '<span class="cooked-tax-column">';
@@ -1037,7 +1037,7 @@ class Cooked_Recipes {
 
 				echo '<div class="cooked-fields-wrap cooked-' . esc_attr( $tax_col_count ) . '-search-fields">';
 
-					echo ( !$options['hide_browse'] && $taxonomy_search_fields ? esc_html( $taxonomy_search_fields ) : '' );
+					echo ( !$options['hide_browse'] && $taxonomy_search_fields ? $taxonomy_search_fields : '' );
 
 					echo '<input class="cooked-browse-search" type="text" name="cooked_search_s" value="' . ( isset($_GET['cooked_search_s']) && $_GET['cooked_search_s'] ? Cooked_Functions::sanitize_text_field( $_GET['cooked_search_s'] ) : '' ) . '" placeholder="' . esc_attr__('Find a recipe...','cooked') . '" />';
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: boxystudio, xjsv
 Tags: recipe, recipes, food, cooking, nutrition
 Requires at least: 4.7
 Tested up to: 6.5.2
-Stable tag: 1.7.15.2
+Stable tag: 1.7.15.3
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -78,6 +78,9 @@ Be sure to check the [Cooked Documentation](http://docs.cooked.pro/collection/1-
 Version 1.7.15.2 is a hotfix to correct the composer platform error issue.
 
 == Changelog ==
+
+= 1.7.15.3 =
+* **FIX:** HTML showing in front end when using the [cooked-browse] shortcode.
 
 = 1.7.15.2 =
 * **FIX:** Composer detected issues in your platform error discovered by @ianrlp.


### PR DESCRIPTION
Fixed HTML showing in front end when using the [cooked-browse] shortcode.